### PR TITLE
Add Python requirements file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Python modules required for H2O build.
+# Install the modules using pip:
+#    pip install -r requirements.txt [--user]
+sphinxcontrib-fulltoc


### PR DESCRIPTION
I added the Python requirements.txt file with the Sphinx-doc module necessary to build documentation.
Use the file with `pip` command:

```
pip install -r requirements.txt [--user]
```

Fixes `make` build error:

make[2]: Entering directory `/home/vmlaker/work/git-h2o/h2o-docs'
sphinx-build -b html -d build/doctrees   source build/html
Making output directory...
Running Sphinx v1.1.3

Extension error:
Could not import extension sphinxcontrib.fulltoc (exception: No module named fulltoc)
make[2]: **\* [html] Error 1
make[2]: Leaving directory `/home/vmlaker/work/git-h2o/h2o-docs'
make[1]: *** [dw_2] Error 2
make[1]: Leaving directory`/home/vmlaker/work/git-h2o'
make: **\* [nightly_build_stuff] Error 2
