### PR TITLE
Making some setters public so driver can be used in other methods

### DIFF
--- a/h2o-zookeeper/src/main/java/water/zookeeper/h2odriver.java
+++ b/h2o-zookeeper/src/main/java/water/zookeeper/h2odriver.java
@@ -23,19 +23,19 @@ public class h2odriver {
   public static boolean g_start = false;
   public static boolean g_wait = false;
 
-  void setZk(String v) {
+  public void setZk(String v) {
     _zk = v;
   }
 
-  void setZkroot(String v) {
+  public void setZkroot(String v) {
     _zkroot = v;
   }
 
-  void setNumNodes(int v) {
+  public void setNumNodes(int v) {
     _numNodes = v;
   }
 
-  void setCloudFormationTimeoutSeconds(int v) {
+  public void setCloudFormationTimeoutSeconds(int v) {
     _cloudFormationTimeoutSeconds = v;
   }
 


### PR DESCRIPTION
I'm using the h2odriver from within another class in the Mesos framework and it would be nice to have public setters. 
