### PR TITLE
remove unused imports (that may cause the build to fail)

### DIFF
--- a/src/main/java/hex/singlenoderf/TwoingStatistic.java
+++ b/src/main/java/hex/singlenoderf/TwoingStatistic.java
@@ -4,9 +4,6 @@ import water.util.Utils;
 
 import java.util.Random;
 
-import org.junit.Test;
-import org.junit.Assert;
-
 /** Computes the twoing split statistic.
  *
  * The decrease in (twoing) impurity as the result of a given split is


### PR DESCRIPTION
The junit imports are unused and may cause the build to fail since junit is only declared as test dependency.
