### PR TITLE
Bugfix for case where N is not divisible by num CV folds

### DIFF
--- a/R/ensemble/README.md
+++ b/R/ensemble/README.md
@@ -7,13 +7,13 @@ The `h2oEnsemble` R package provides functionality to create ensembles from the 
 The `h2oEnsemble` package can be installed using either of the following methods.
 - Clone the main h2o repository and install the package:
 ```
-git clone https://github.com/0xdata/h2o.git
+git clone https://github.com/h2oai/h2o.git
 R CMD INSTALL h2o/R/ensemble/h2oEnsemble-package
 ```
 - Install in R using `devtools::install_github`:
 ```
 library(devtools)
-install_github("0xdata/h2o/R/ensemble/h2oEnsemble-package")
+install_github("h2oai/h2o/R/ensemble/h2oEnsemble-package")
 ```
 
 ## Create Ensembles

--- a/R/ensemble/h2oEnsemble-package/DESCRIPTION
+++ b/R/ensemble/h2oEnsemble-package/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: h2oEnsemble
 Type: Package
 Title: H2O Ensemble Learning
-Version: 0.0.2
-Date: 2014-11-17
+Version: 0.0.3
+Date: 2014-12-28
 Author: Erin LeDell
 Maintainer: Erin LeDell <ledell@berkeley.edu>
-Description: This package implements the super learner ensemble (stacking) algorithm using the H2O R interface to provide base leanrning algorithms.   
+Description: This package implements the super learner ensemble (stacking) algorithm using the H2O R interface to provide base learning algorithms.   
 License: Apache License (== 2.0)
 Depends: R (>= 2.13.0), h2o
 NeedsCompilation: no
 SystemRequirements: Java (>= 1.6)
 Suggests: SuperLearner, cvAUC
-URL: http://www.0xdata.com
+URL: https://github.com/h2oai/h2o/tree/master/R/ensemble/h2oEnsemble-package

--- a/R/ensemble/h2oEnsemble-package/NEWS
+++ b/R/ensemble/h2oEnsemble-package/NEWS
@@ -1,6 +1,11 @@
 # News for the h2oEnsemble package. #
 
 
+h2oEnsemble 0.0.3 (2014-12-28)
+----------------
+* Fixed bug in `h2o.ensemble` that occurred when the number of observations is not divisible by the number of internal CV folds.
+
+
 h2oEnsemble 0.0.2 (2014-11-17)
 ----------------
 * Removed rounding in `h2o.ensemble.predict`.

--- a/R/ensemble/h2oEnsemble-package/R/ensemble.R
+++ b/R/ensemble/h2oEnsemble-package/R/ensemble.R
@@ -47,7 +47,7 @@ function(x, y, data, family = "binomial",
     
   # Begin ensemble code
   if (is.numeric(seed)) set.seed(seed)  #If seed is specified, set seed prior to next step
-  folds <- sample(rep(seq(V), N/V))  # Cross-validation folds (stratified folds not yet supported)
+  folds <- sample(rep(seq(V), ceiling(N/V)))[1:N]  # Cross-validation folds (stratified folds not yet supported)
   data$fold_id <- folds  # Add a fold_id column for each observation so we can subset by row later
   
   # Create the Z matrix of cross-validated predictions

--- a/R/ensemble/h2oEnsemble-package/man/h2oEnsemble-package.Rd
+++ b/R/ensemble/h2oEnsemble-package/man/h2oEnsemble-package.Rd
@@ -6,14 +6,14 @@
 H2O Ensemble Package
 }
 \description{
-This package implements the super learner ensemble (stacking) algorithm using the H2O R interface to provide base leanrning algorithms. 
+This package implements the super learner ensemble (stacking) algorithm using the H2O R interface to provide base learning algorithms. 
 }
 \details{
 \tabular{ll}{
 Package: \tab h2oEnsemble\cr
 Type: \tab Package\cr
-Version: \tab 0.0.2\cr
-Date: \tab 2014-11-17\cr
+Version: \tab 0.0.3\cr
+Date: \tab 2014-12-28\cr
 License: \tab Apache License (== 2.0)\cr
 }
 }


### PR DESCRIPTION
There was a bug that occurred when the number of training observations was not divisible by the number of internal CV folds (as specified in the `cvControl` argument of `h2o.ensemble`).  This has been fixed. 

This PR also includes a few edits to the documentation.
