### PR TITLE
Fix misleading glm CV documentation

### DIFF
--- a/h2o-docs/source/datascience/glm.rst
+++ b/h2o-docs/source/datascience/glm.rst
@@ -147,7 +147,7 @@ Defining a GLM Model
      Specify the number of cross-validation models to 
      generate simultaneously for training a model on the full data
      set. If N folds is set to 10, additional models are generated
-     with 1/10 of the data used to train each. The purpose of N folds
+     with 9/10 of the data used to train each. The purpose of N folds
      is to evaluate the stability of the parameter estimates.
 
 **Alpha:**


### PR DESCRIPTION
Hey guys.

I'm assuming this 1/10 is a typo. It could easily mislead folks who are new to the idea of CV.

I think there are a couple of other spots that say 1/10. The docs/glm/GLM_Vignette.\* files have the same string. 
