### PR TITLE
Disable the default builds report generation function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
   <properties>
     <!-- Default compile time version of Hadoop client: in H2O lib-directory structured referenced as cdh3. -->
     <h2o.hadoop.version>0.20.2-cdh3u6</h2o.hadoop.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <!-- Repositories -->
@@ -240,6 +241,7 @@
          <configuration>
            <!-- FIXME: we still have no proper JUnit runner for H2O tests -->
            <skipTests>true</skipTests>
+         	<disableXmlReport>${closeTestReports}</disableXmlReport>
          </configuration>
        </plugin>
     </plugins>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
